### PR TITLE
Get ready for updated plan pages

### DIFF
--- a/_includes/structure/header.html
+++ b/_includes/structure/header.html
@@ -1,12 +1,3 @@
-<!-- Navigation -->
-<div class="pubexpsurvey">
-  <div class="container">
-    <img src="http://ashleymmeyers.github.io/sf/survey-banner/comment2.png" class="pubexpsurveyicon"> 
-    <p>We'd love feedback on your experience using City online services: 
-      <a href="https://sfmoci.typeform.com/to/gv2T4Z" target="_blank">Take a short 5-minute survey.</a>
-    </p>
-  </div>
-</div>
 <div class="nav-group navbar-fixed-top {% if page.is_front != true %} navbar-shrink {% endif %}">
   <nav class="navbar navbar-mini navbar-static-top visible-sm visible-md visible-lg" role="region" aria-label="external links">
     <div class="container">

--- a/assets/js/plans.js
+++ b/assets/js/plans.js
@@ -111,7 +111,9 @@ var buildPage = function(dept, url, table) {
       field: 'field_20',
       operator: 'is',
       value: deptFilter
-    }]
+    }, {"field":"field_45","operator":"is before","value":"12/31/2015","field_name":"Approval Date"}]
+    
+    
 
     $.ajax({
       url: "https://api.knackhq.com/v1/scenes/scene_42/views/view_57/records?filters=" + encodeURIComponent(JSON.stringify(filters)),

--- a/assets/js/plans.js
+++ b/assets/js/plans.js
@@ -166,8 +166,8 @@ var buildPage = function(dept, url, table) {
   }
 
   if (table) {
-    deptFilter = deptFilter == '' ? '' : '(^' + deptFilter + '$)'
-    table.columns(1).search(deptFilter, true, false).draw()
+    var search = deptFilter == '' ? '' : '(^' + deptFilter + '$)'
+    table.columns(1).search(search, true, false).draw()
   }
 }
 

--- a/assets/js/plans.js
+++ b/assets/js/plans.js
@@ -165,8 +165,7 @@ var buildPage = function(dept, url, table) {
 
   if (table) {
     deptFilter = deptFilter == '' ? '' : '(^' + deptFilter + '$)'
-    table.columns(1).search(deptFilter, true, false).draw();
-    debugger
+    table.columns(1).search(deptFilter, true, false).draw()
   }
 }
 

--- a/assets/js/plans.js
+++ b/assets/js/plans.js
@@ -164,7 +164,9 @@ var buildPage = function(dept, url, table) {
   }
 
   if (table) {
-    table.columns(1).search(deptFilter).draw();
+    deptFilter = deptFilter == '' ? '' : '(^' + deptFilter + '$)'
+    table.columns(1).search(deptFilter, true, false).draw();
+    debugger
   }
 }
 


### PR DESCRIPTION
This PR modifies the Knack query so we can approve plans without them being included in the current interface. This will allow me to test the rollout of new plans, including slight interface changes, without affecting the previous plans.